### PR TITLE
Removes the InternalsVisibleTo attribute to the unit test project when compiling in Release mode.

### DIFF
--- a/AspNet.WebForms.DependencyInjection/Properties/AssemblyInfo.cs
+++ b/AspNet.WebForms.DependencyInjection/Properties/AssemblyInfo.cs
@@ -6,4 +6,6 @@
 
 using System.Runtime.CompilerServices;
 
+#if DEBUG
 [assembly: InternalsVisibleTo("PosInformatique.AspNet.WebForms.DependencyInjection.Tests")]
+#endif


### PR DESCRIPTION
It is required to sign the assembly with the Azure DevOps pipeline.